### PR TITLE
Adding missing configuration to httpd.conf

### DIFF
--- a/docker/fts3/fts3.13/Containerfile
+++ b/docker/fts3/fts3.13/Containerfile
@@ -87,6 +87,12 @@ RUN echo "" >> /etc/httpd/conf/httpd.conf
 RUN echo "# Always append SAMEORIGIN" >> /etc/httpd/conf/httpd.conf
 RUN echo "Header always append X-Frame-Options SAMEORIGIN" >> /etc/httpd/conf/httpd.conf
 
+#> Hide Apache Version and Os Version
+RUN echo "" >> /etc/httpd/conf/httpd.conf
+RUN echo "# Hide Apache Version and Os Version" >> /etc/httpd/conf/httpd.conf
+RUN echo "ServerTokens Prod" >> /etc/httpd/conf/httpd.conf
+RUN echo "ServerSignature Off" >> /etc/httpd/conf/httpd.conf
+
 #> Needed for pure k8s environment
 RUN chown fts3:root /var/log/fts3rest && chmod 644 /etc/fts3web/fts3web.ini
 


### PR DESCRIPTION
This change fixes the issue reported on RITM2220649 about Server headers exposing sensitive data.

https://fermi.servicenowservices.com/nav_to.do?uri=%2Fsc_req_item.do%3Fsys_id%3D91feacae97a01e50e47ebb4ad053af1b%26sysparm_view%3D%26sysparm_domain%3Dnull%26sysparm_domain_scope%3Dnull